### PR TITLE
Update schema-loader and dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,60 +1,58 @@
 const { inklecate } = require('inklecate');
-const {
-  getOptions,
-} = require('loader-utils');
-const validateOptions = require('schema-utils');
+const { getOptions } = require('loader-utils');
+const { validate } = require('schema-utils');
 
 const schema = {
-  type: 'object',
-  properties: {
-    countAllVisits: {
-      type: 'boolean',
-    },
+	type: 'object',
+	properties: {
+		countAllVisits: {
+			type: 'boolean',
+		},
 
-    inputFilepath: {
-      type: 'string',
-    },
+		inputFilepath: {
+			type: 'string',
+		},
 
-    verbose: {
-      type: 'boolean',
-    },
+		verbose: {
+			type: 'boolean',
+		},
 
-    DEBUG: {
-      type: 'boolean',
-    },
-  }
+		DEBUG: {
+			type: 'boolean',
+		},
+	},
 };
 
 module.exports = function InkWebpackLoader(content, map, meta) {
-  const options = getOptions(this) || {};
+	const options = getOptions(this) || {};
 
-  validateOptions(schema, options, 'Example Loader');
+	validate(schema, options, 'InklecateLoader');
 
-  const callback = this.async();
+	const callback = this.async();
 
-  const inklecateOpts = {
-    countAllVisits: Boolean(options.countAllVisits),
-    inputFilepath: this.resourcePath,
-    verbose: Boolean(options.verbose),
-    DEBUG: Boolean(options.DEBUG),
-  };
+	const inklecateOpts = {
+		countAllVisits: Boolean(options.countAllVisits),
+		inputFilepath: this.resourcePath,
+		verbose: Boolean(options.verbose),
+		DEBUG: Boolean(options.DEBUG),
+	};
 
-  inklecate(inklecateOpts).then(
-    function resolved(data) {
-      callback(
-        null,
-        `module.exports = ${JSON.stringify({
-          compilerOutput: data.compilerOutput,
-          storyContent: data.storyContent,
-          text: content.trim(),
-        })};\n`,
-        map,
-        meta,
-      );
-    },
+	inklecate(inklecateOpts).then(
+		function resolved(data) {
+			callback(
+				null,
+				`module.exports = ${JSON.stringify({
+					compilerOutput: data.compilerOutput,
+					storyContent: data.storyContent,
+					text: content.trim(),
+				})};\n`,
+				map,
+				meta
+			);
+		},
 
-    function rejected(err) {
-      return callback(typeof err === Error ? err : new Error(err));
-    },
-  );
+		function rejected(err) {
+			return callback(typeof err === Error ? err : new Error(err));
+		}
+	);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,133 @@
 {
   "name": "inklecate-loader",
-  "version": "1.7.0",
-  "lockfileVersion": 1,
+  "version": "1.7.2",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "inklecate-loader",
+      "version": "1.7.2",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "inklecate": "^1.8.1"
+      },
+      "devDependencies": {
+        "bufferutil": "^4.0.6",
+        "utf-8-validate": "^5.0.9"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "node_modules/inklecate": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/inklecate/-/inklecate-1.8.1.tgz",
+      "integrity": "sha512-xk4nd6pezh8B4J6Jqvdv/u85jx7hZIEEoNe8b9Dy4sU8ecftjYQ117cWOEcwuPF+2BcyiIdj/7/eE57nVzpSfQ==",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "fs-extra": "^8.1.0",
+        "ts-assertions": "^2.0.5",
+        "uuid": "^8.2.0"
+      },
+      "bin": {
+        "inklecate": "cli.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/ts-assertions": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/ts-assertions/-/ts-assertions-2.0.6.tgz",
+      "integrity": "sha512-9lqaCPgeYS80HICaq8WYcmonqfy7A6I1MDL5QtHB6PGwKFmcPd6tZKe0fh54+/Cd9y6B3uRIjCZMH9mK19HjFw=="
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
   "dependencies": {
     "bufferutil": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
-      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
       "dev": true,
       "requires": {
-        "node-gyp-build": "~3.7.0"
+        "node-gyp-build": "^4.3.0"
       }
     },
     "commander": {
@@ -34,9 +151,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "inklecate": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/inklecate/-/inklecate-1.7.1.tgz",
-      "integrity": "sha512-oAqZDp5XMf+0UpOwJObiqJapfKdv6ysx8re5fuEqPv0y/Z+iFMn5HXOIEkTESqHlN0sGeVMpWDaCB1cJPElviA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/inklecate/-/inklecate-1.8.1.tgz",
+      "integrity": "sha512-xk4nd6pezh8B4J6Jqvdv/u85jx7hZIEEoNe8b9Dy4sU8ecftjYQ117cWOEcwuPF+2BcyiIdj/7/eE57nVzpSfQ==",
       "requires": {
         "commander": "^2.20.3",
         "fs-extra": "^8.1.0",
@@ -53,9 +170,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-      "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
       "dev": true
     },
     "ts-assertions": {
@@ -69,12 +186,12 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "utf-8-validate": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
-      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
       "dev": true,
       "requires": {
-        "node-gyp-build": "~3.7.0"
+        "node-gyp-build": "^4.3.0"
       }
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -1,35 +1,38 @@
 {
-  "name": "inklecate-loader",
-  "version": "1.7.2",
-  "description": "A webpack loader to convert .ink files into compiled story JSON, using the official inklecate binaries.",
-  "main": "index.js",
-  "scripts": {
-    "test": "jest"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/furkleindustries/inklecate-loader.git"
-  },
-  "keywords": [
-    "inklecate",
-    "webpack",
-    "loader",
-    "ink",
-    "inkle",
-    "IF",
-    "hypertext"
-  ],
-  "author": "furkle",
-  "license": "GPL-3.0",
-  "bugs": {
-    "url": "https://github.com/furkleindustries/inklecate-loader/issues"
-  },
-  "homepage": "https://github.com/furkleindustries/inklecate-loader#readme",
-  "dependencies": {
-    "inklecate": "^1.7.1"
-  },
-  "devDependencies": {
-    "bufferutil": "^4.0.1",
-    "utf-8-validate": "^5.0.2"
-  }
+	"name": "inklecate-loader",
+	"version": "1.7.2",
+	"description": "A webpack loader to convert .ink files into compiled story JSON, using the official inklecate binaries.",
+	"main": "index.js",
+	"scripts": {
+		"test": "jest"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/furkleindustries/inklecate-loader.git"
+	},
+	"keywords": [
+		"inklecate",
+		"webpack",
+		"loader",
+		"ink",
+		"inkle",
+		"IF",
+		"hypertext"
+	],
+	"author": "furkle",
+	"license": "GPL-3.0",
+	"bugs": {
+		"url": "https://github.com/furkleindustries/inklecate-loader/issues"
+	},
+	"homepage": "https://github.com/furkleindustries/inklecate-loader#readme",
+	"dependencies": {
+		"inklecate": "^1.8.1"
+	},
+	"devDependencies": {
+		"bufferutil": "^4.0.6",
+		"utf-8-validate": "^5.0.9"
+	},
+	"peerDependencies": {
+		"schema-utils": "^4.0.0"
+	}
 }


### PR DESCRIPTION
When using inkecate-loader, I was getting errors:

> Module build failed (from ./node_modules/inklecate-loader/index.js):
> TypeError: validateOptions is not a function
>     at Object.InkWebpackLoader (/Users/david/prog/a_five_room_dungeon/web/node_modules/inklecate-loader/index.js:31:3)

This seems to be because the API for schema-loader has changed. 

This pull request:

* Changes the loader to use schema-loader v4's API
* Adds a peer dependency on schema-loader v4 so mismatched versions will get npm to shout at the user
* Updates the other dependencies
* Replaces the placeholder *Example Loader* text
* Lets my code formatter go to town (sorry about that, I could reapply my changes manually if you care about that).
